### PR TITLE
Fix Idea Title in IE

### DIFF
--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -81,6 +81,7 @@ img.grayscale:hover {
 }
 
 h1.no-margins {
+    margin: 0px;
     margin-block-end: 0;
     margin-block-start: 0;
     -webkit-margin-after: 0;

--- a/src/ideas/ideasView/ideasView.tpl.html
+++ b/src/ideas/ideasView/ideasView.tpl.html
@@ -3,7 +3,7 @@
     <md-card-content class="no-padding-all">
         <div ng-if="!ideasView.enableEdit">
             <div layout="column" layout-align="space-between center" class="top-bar extra-padding-sides-15 center-text">
-                <div flex=75>
+                <div>
                     <h1 class="no-margins word-wrap center-text">{{idea.title}}</h1>
                     <small>
                         <span class="center-stuff" ng-show="idea.timeModified === idea.timeCreated">Created&nbsp</span>


### PR DESCRIPTION
The idea title was not displaying properly in IE as can be seen on production right now.  Just removed an unused flex.  Also added in a `margin: 0px` so that the the spacing is the same in Chrome and IE.

@Mctalian @monotkate @YashdalfTheGray @bcbrennecke 

- [x] - Reviewer 1
- [x] - Reviewer 2