### PR TITLE
Navigating to a non-existent idea behaves appropriately.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -139,6 +139,7 @@ gulp.task('start:dev', ['test:client', 'inject', 'generate:data'], function() {
         script: 'server/server.js',
         env: { 'NODE_ENV': 'development' },
         'ignore': [
+            'coverage/*',
             'server/datastore/*',
             'src/*'
         ]
@@ -152,6 +153,7 @@ gulp.task('start:test', ['test:client', 'inject'], function() {
         script: 'server/server.js',
         env: { 'NODE_ENV': 'test' },
         'ignore': [
+            'coverage/*',
             'server/datastore/*',
             'src/*'
         ]
@@ -165,6 +167,7 @@ gulp.task('start:prod', ['test:client', 'inject'], function() {
         script: 'server/server.js',
         env: { 'NODE_ENV': 'production' },
         'ignore': [
+            'coverage/*',
             'server/datastore/*',
             'src/*'
         ]

--- a/src/ideas/ideasView/ideasView.js
+++ b/src/ideas/ideasView/ideasView.js
@@ -66,16 +66,12 @@ angular.module('flintAndSteel')
 
             ctrl.refreshIdea = function() {
                 ideaSvc.getIdea($stateParams.ideaId).then(function getIdeaSuccess(response) {
-                    if (response.data === 'IDEA_NOT_FOUND') {
-                        toastSvc.show('Sorry, that idea does not exist');
-                        $state.go('home');
-                    }
-                    else {
-                        $scope.idea = response.data;
-                        ctrl.enableEdit = false;
-                        ctrl.refreshTeam();
-                    }
+                    $scope.idea = response.data;
+                    ctrl.enableEdit = false;
+                    ctrl.refreshTeam();
                 }, function getIdeaError(response) {
+                    toastSvc.show('Sorry, that idea does not exist');
+                    $state.go('home');
                     console.log(response);
                 });
             };

--- a/src/ideas/ideasView/ideasView.spec.js
+++ b/src/ideas/ideasView/ideasView.spec.js
@@ -107,15 +107,14 @@ describe('IdeasViewCtrl', function() {
 
         it('should notify if idea is not found', function() {
             spyOn(ideaSvcMock, 'getIdea').and.callFake(function getIdea() {
-                return $q.when({data: 'IDEA_NOT_FOUND'});
+                return $q.reject();
             });
+            spyOn(console, 'log').and.callFake(function() {});
 
             ctrl.refreshIdea();
             scope.$digest();
-            ideaSvcMock.getIdea().then(function() {
-                expect(toastSvc.show).toHaveBeenCalled();
-                expect($state.go).toHaveBeenCalled();
-            });
+            expect(toastSvc.show).toHaveBeenCalled();
+            expect($state.go).toHaveBeenCalled();
         });
 
         it('should output a console log if an idea error', function() {


### PR DESCRIPTION
This used to work, but the back-end changes broke this.

When navigating to an idea that doesn't exist (someone deleted it and you're following a link to the deleted idea), it was supposed to reroute you back to the home state and toast you with "Sorry, that idea doesn't exist" or something to that effect.

What it was doing was just displaying a blank idea page. Now it's fixed.

Reviewers: 
- [x] @bcbrennecke (or other)
- [x] @alanlgirard (or other)