### PR TITLE
Fix for #258

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -411,14 +411,22 @@ module.exports = function(app, db) {
         var sse = startSees(res);
 
         function updateHeaders(headers) {
-            replaceIds.headers(headers).then(function(headersData) {
-                var headersToSend = headersData.map(function(singleHeader) {
-                    return singleHeader[0];
-                });
+            // If the last idea is deleted, we send an empty array of headers.
+            if (typeof headers === 'undefined') {
+                var headersToSend = [];
                 sse("newHeaders", headersToSend);
-            }).catch(function(err) {
-                console.error(chalk.bgRed(err));
-            });
+            }
+            // Otherwise, we process the headers and send the results.
+            else {
+                replaceIds.headers(headers).then(function(headersData) {
+                    var headersToSend = headersData.map(function(singleHeader) {
+                        return singleHeader[0];
+                    });
+                    sse("newHeaders", headersToSend);
+                }).catch(function(err) {
+                    console.error(chalk.bgRed(err));
+                });
+            }
         }
 
         IdeasInstance.on("newHeaders", updateHeaders);

--- a/server/routes.js
+++ b/server/routes.js
@@ -412,7 +412,7 @@ module.exports = function(app, db) {
 
         function updateHeaders(headers) {
             // If the last idea is deleted, we send an empty array of headers.
-            if (typeof headers === 'undefined') {
+            if (!headers) {
                 var headersToSend = [];
                 sse("newHeaders", headersToSend);
             }


### PR DESCRIPTION
This PR will close #258


## Background on SSEs
This issue is focused on Server-Sent Events (SSEs). SSEs send updates to all of the clients listening to a particular event and are triggered anytime the associated resource is updated. For instance, if an author edits his idea, an SSE for that particular idea is sent out to all the clients currently looking at that idea and it causes the data to be refreshed without the user doing anything. This also happens when an interaction is posted to an idea.

Aside from specific idea SSEs, there is also an SSE associated with the idea headers that are used for the sidenav and the All Ideas view. Anytime any idea is updated in some way, or a new idea is created, or an existing idea is deleted, this SSE is triggered, updating ALL active clients because they are all "viewing" the sidenav all the time.

## The Problem
When deleting the only remaining idea, the SSE would fire with an undefined idea because it no longer exists. The first thing we do in the post processing of idea headers (now within `replaceIds.js`) is check if the number of headers is 0. If the headers are undefined, checking the length property of undefined crashes the server.

Deleting the only remaining idea crashes the server with a `TypeError` for trying to read a property from an undefined variable.

## The Solution
A simple solution was to add a check to the SSE for updating the idea headers. This check ensures that the headers are defined before running post processing (`replaceIds.js`) on the idea. In the event that the headers are undefined, we simply send an empty array back to the listening clients, and they successfully show "No ideas" in the sidenav.

## Demo

**Before**
![issue_258_broken](https://cloud.githubusercontent.com/assets/5081281/12998125/e29ef4f0-d10d-11e5-8a75-0f724636c371.gif)

**After**
![issue_258_fixed](https://cloud.githubusercontent.com/assets/5081281/12998136/e8e290ba-d10d-11e5-9567-e9408b1823f4.gif)

## Reviewers
@bcbrennecke, @YashdalfTheGray, @alanlgirard, @davethenipper
- [x] Code Review 1 @YashdalfTheGray
- [x] Code Review 2 @bcbrennecke
- [x] Functionality Review 1 @bcbrennecke
- [x] Functionality Review 2 @YashdalfTheGray