### PR TITLE
Completed: Feature 3- Mobile user menu

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -337,6 +337,7 @@ h2.no-bottom-margin {
 
 .identicon-home {
     margin-right: 10px;
+    margin-left: 10px;
 }
 
 .md-tab.md-active {

--- a/src/index.html
+++ b/src/index.html
@@ -123,8 +123,8 @@
                 <div class="user-menu" ng-show="isUserLoggedIn()">
                     <md-menu md-offset="0 60">
                         <md-button aria-label="Open demo menu" ng-click="$mdOpenMenu($event)">
+                            <span hide show-gt-sm>{{currentUser}}</span>
                             <identicon md-menu-origin="" username='getUsername()' size='24' class="identicon identicon-home"></identicon>
-                            {{currentUser}}
                             <i class="material-icons icon-button-adjust">&#xE5CF;</i>
                         </md-button>
                         <md-menu-content width="4">


### PR DESCRIPTION
User's name does not show for smaller screens.

User's name was moved to the other side of the identicon per Fan4
discussion and UX recommendation.

Added extra left margin to identicon so name wasn't butting right up
against it.

The caret is still there.

@monotkate, @davethenipper 

I received PO, UX, and Test approval already so please take a quick look at my code.

- [x]  @monotkate 
- [x]  @alanlgirard